### PR TITLE
Add mustache cache example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,26 +49,22 @@ Enviroments:
 
 Under the condition of 10000 times tests with 10 times repeat to achieve more accuracy, the benchmark results are:
 
--	NATIVE
+    ===NATIVE===
+    Simple Test: 146.19399414062ms, 310.4byte PHP, 0byte System
+    Loop Test: 136.38813476563ms, 236byte PHP, 26214.4byte System
 
-	Simple Test: 150.80124511719ms, 388.8byte PHP, 0byte System
+    ===MUSTACHE===
+    Simple Test: 395.30563964844ms, 23620.8byte PHP, 52428.8byte System
+    Loop Test: 780.89516601563ms, 2816byte PHP, 0byte System
 
-	Loop Test: 115.1564453125ms, 401.6byte PHP, 0byte System
+    ===MUSTACHE CACHED===
+    Simple Test: 152.10305175781ms, 200byte PHP, 0byte System
+    Loop Test: 459.80954589844ms, 200byte PHP, 0byte System
 
--	MUSTACHE
+    ===TWIG===
+    Simple Test: 176.93303222656ms, 131239.2byte PHP, 157286.4byte System
+    Loop Test: 544.47629394531ms, 15188byte PHP, 0byte System
 
-	Simple Test: 653.93806152344ms, 13515.2byte PHP, 26214.4byte System
-
-	Loop Test: 1284.2868408203ms, 2468byte PHP, 0byte System
-
--	TWIG
-
-	Simple Test: 461.39296875ms, 81692byte PHP, 52428.8byte System
-
-	Loop Test: 1142.9485595703ms, 14024byte PHP, 26214.4byte System
-
--	SMARTY
-
-	Simple Test: 747.65390625ms, 255336byte PHP, 262144byte System
-
-	Loop Test: 915.72463378906ms, 6268byte PHP, 0byte System
+    ===SMARTY===
+    Simple Test: 264.49147949219ms, 260452byte PHP, 262144byte System
+    Loop Test: 327.04890136719ms, 6908.8byte PHP, 0byte System

--- a/mustache-cached/cache/__MyTemplates_412390a2c222edbc114ececf5bdc5fce.php
+++ b/mustache-cached/cache/__MyTemplates_412390a2c222edbc114ececf5bdc5fce.php
@@ -1,0 +1,54 @@
+<?php
+
+class __MyTemplates_412390a2c222edbc114ececf5bdc5fce extends Mustache_Template
+{
+    private $lambdaHelper;
+
+    public function renderInternal(Mustache_Context $context, $indent = '')
+    {
+        $this->lambdaHelper = new Mustache_LambdaHelper($this->mustache, $context);
+        $buffer = '';
+
+        $buffer .= $indent . '<div class="comments">    <h3>';
+        $value = $this->resolveValue($context->find('header'), $context, $indent);
+        $buffer .= htmlspecialchars($value, 2, 'UTF-8');
+        $buffer .= '</h3>    <ul>        ';
+        // 'comments' section
+        $value = $context->find('comments');
+        $buffer .= $this->sectionF366dc769fb785da783404452b0e6516($context, $indent, $value);
+        $buffer .= '    </ul></div>';
+
+        return $buffer;
+    }
+
+    private function sectionF366dc769fb785da783404452b0e6516(Mustache_Context $context, $indent, $value)
+    {
+        $buffer = '';
+        if (!is_string($value) && is_callable($value)) {
+            $source = '        <li class="comment">            <h5>{{ name }}</h5>            <p>{{ body }}</p>        </li>        ';
+            $result = call_user_func($value, $source, $this->lambdaHelper);
+            if (strpos($result, '{{') === false) {
+                $buffer .= $result;
+            } else {
+                $buffer .= $this->mustache
+                    ->loadLambda((string) $result)
+                    ->renderInternal($context);
+            }
+        } elseif (!empty($value)) {
+            $values = $this->isIterable($value) ? $value : array($value);
+            foreach ($values as $value) {
+                $context->push($value);
+                $buffer .= '        <li class="comment">            <h5>';
+                $value = $this->resolveValue($context->find('name'), $context, $indent);
+                $buffer .= htmlspecialchars($value, 2, 'UTF-8');
+                $buffer .= '</h5>            <p>';
+                $value = $this->resolveValue($context->find('body'), $context, $indent);
+                $buffer .= htmlspecialchars($value, 2, 'UTF-8');
+                $buffer .= '</p>        </li>        ';
+                $context->pop();
+            }
+        }
+    
+        return $buffer;
+    }
+}

--- a/mustache-cached/cache/__MyTemplates_dff2b2a2afa3817617db5bd28c95aaf2.php
+++ b/mustache-cached/cache/__MyTemplates_dff2b2a2afa3817617db5bd28c95aaf2.php
@@ -1,0 +1,25 @@
+<?php
+
+class __MyTemplates_dff2b2a2afa3817617db5bd28c95aaf2 extends Mustache_Template
+{
+    public function renderInternal(Mustache_Context $context, $indent = '')
+    {
+        $buffer = '';
+
+        $buffer .= $indent . '<div class="test">    <h2>This is a test of ';
+        $value = $this->resolveValue($context->find('name'), $context, $indent);
+        $buffer .= htmlspecialchars($value, 2, 'UTF-8');
+        $buffer .= '</h2>    <p>The homepage is <a href="';
+        $value = $this->resolveValue($context->find('url'), $context, $indent);
+        $buffer .= htmlspecialchars($value, 2, 'UTF-8');
+        $buffer .= '">';
+        $value = $this->resolveValue($context->find('url'), $context, $indent);
+        $buffer .= htmlspecialchars($value, 2, 'UTF-8');
+        $buffer .= '</a>.</p>    <p>The sources is: ';
+        $value = $this->resolveValue($context->find('source'), $context, $indent);
+        $buffer .= htmlspecialchars($value, 2, 'UTF-8');
+        $buffer .= '</p></div>';
+
+        return $buffer;
+    }
+}

--- a/mustache-cached/mustache.php
+++ b/mustache-cached/mustache.php
@@ -1,0 +1,38 @@
+<?php
+require dirname(__FILE__). '/../benchmark.php';
+require dirname(__FILE__). '/../libs/mustache/src/Mustache/Autoloader.php';
+Mustache_Autoloader::register();
+$mustache = new Mustache_Engine(array(
+    'template_class_prefix' => '__MyTemplates_',
+    'cache' => dirname(__FILE__). '/cache',
+    'loader' => new Mustache_Loader_FilesystemLoader(dirname(__FILE__).'/templates'),
+));
+$data = json_decode(file_get_contents(dirname(__FILE__). '/../data/data.json'), true);
+
+// load templates
+$tpl_simple = $mustache->loadTemplate('story');
+$tpl_loop = $mustache->loadTemplate('comment');
+
+// warm up
+$tpl_simple->render($data['story_view']);
+$tpl_loop->render($data['comment_view']);
+
+function test_simple() {
+    global $tpl_simple;
+    global $data;
+    $tpl_simple->render($data['story_view']);
+}
+
+function test_loop() {
+    global $tpl_loop;
+    global $data;
+    $tpl_loop->render($data['comment_view']);
+}
+
+$simpleResults =  benchmark(10, 10000, 'test_simple', true);
+echo 'Simple Test: ', $simpleResults['time'], 'ms, ', $simpleResults['PhpMemory'], 'byte PHP, ', $simpleResults['RealMemory'], 'byte System',PHP_EOL;
+$loopResults =  benchmark(10, 10000, 'test_loop', true);
+echo 'Loop Test: ', $loopResults['time'], 'ms, ', $loopResults['PhpMemory'], 'byte PHP, ', $loopResults['RealMemory'], 'byte System',PHP_EOL;
+
+
+

--- a/mustache-cached/templates/comment.mustache
+++ b/mustache-cached/templates/comment.mustache
@@ -1,0 +1,1 @@
+<div class="comments">    <h3>{{ header }}</h3>    <ul>        {{# comments }}        <li class="comment">            <h5>{{ name }}</h5>            <p>{{ body }}</p>        </li>        {{/ comments }}    </ul></div>

--- a/mustache-cached/templates/story.mustache
+++ b/mustache-cached/templates/story.mustache
@@ -1,0 +1,1 @@
+<div class="test">    <h2>This is a test of {{ name }}</h2>    <p>The homepage is <a href="{{ url }}">{{ url }}</a>.</p>    <p>The sources is: {{ source }}</p></div>

--- a/run.bash
+++ b/run.bash
@@ -11,6 +11,10 @@ echo "===MUSTACHE==="
 php mustache/mustache.php
 echo -e "\n"
 
+echo "===MUSTACHE CACHED==="
+php mustache-cached/mustache.php
+echo -e "\n"
+
 echo "===TWIG==="
 php twig/twig.php
 echo -e "\n"


### PR DESCRIPTION
My results with cached mustache is a lot better:
===NATIVE===
Simple Test: 146.19399414062ms, 310.4byte PHP, 0byte System
Loop Test: 136.38813476563ms, 236byte PHP, 26214.4byte System

===MUSTACHE===
Simple Test: 395.30563964844ms, 23620.8byte PHP, 52428.8byte System
Loop Test: 780.89516601563ms, 2816byte PHP, 0byte System

===MUSTACHE CACHED===
Simple Test: 152.10305175781ms, 200byte PHP, 0byte System
Loop Test: 459.80954589844ms, 200byte PHP, 0byte System

===TWIG===
Simple Test: 176.93303222656ms, 131239.2byte PHP, 157286.4byte System
Loop Test: 544.47629394531ms, 15188byte PHP, 0byte System

===SMARTY===
Simple Test: 264.49147949219ms, 260452byte PHP, 262144byte System
Loop Test: 327.04890136719ms, 6908.8byte PHP, 0byte System
